### PR TITLE
Unused and optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='magic',
           'matplotlib',
           'seaborn',
           'scikit-learn',
-          'networkx',
       ],
       extras_require={
           'FCS': ['fcsparser'],

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,12 @@ setup(name='magic',
           'seaborn',
           'scikit-learn',
           'networkx',
-          'fcsparser',
           'statsmodels',
-          'tables'
       ],
+      extras_require={
+          'FCS': ['fcsparser'],
+          'HDF5': ['tables'],
+      },
       scripts=['src/magic/magic_gui.py',
                'src/magic/MAGIC.py'],
       )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(name='magic',
           'seaborn',
           'scikit-learn',
           'networkx',
-          'statsmodels',
       ],
       extras_require={
           'FCS': ['fcsparser'],

--- a/src/magic/mg.py
+++ b/src/magic/mg.py
@@ -9,7 +9,6 @@ from copy import deepcopy
 from collections import defaultdict, Counter
 from subprocess import call, Popen, PIPE
 import glob
-import tables
 import numpy as np
 import pandas as pd
 
@@ -37,8 +36,6 @@ from numpy.linalg import norm
 from scipy.stats import gaussian_kde
 from scipy.io import mmread
 from numpy.core.umath_tests import inner1d
-
-import fcsparser
 
 import magic
 
@@ -326,6 +323,7 @@ class SCData:
     @classmethod
     def from_fcs(cls, fcs_file, cofactor=5, 
         metadata_channels=['Time', 'Event_length', 'DNA1', 'DNA2', 'Cisplatin', 'beadDist', 'bead1']):
+        import fcsparser
 
         # Parse the fcs file
         text, data = fcsparser.parse( fcs_file )
@@ -439,6 +437,7 @@ class SCData:
 
     @classmethod
     def from_10x_HDF5(cls, filename, genome, use_ensemble_id=True, normalize=True):
+        import tables
 
         with tables.open_file(filename, 'r') as f:
             try:


### PR DESCRIPTION
Following discussion #63, some dependencies as specified in `setup.py` are either never used (`networkx`, `statsmodels`) or only used in some (rare?) cases, typically for I/O (`fcsparser`, `tables`).

I cleaned up the dependency list and added optional dependencies. To keep the package running, I moved `fcsparser` and `tables` imports into their own class methods, so the user only gets an import error while trying to actually parse those file formats.