### PR TITLE
Fixing a typo that renders an error

### DIFF
--- a/R/run_magic.R
+++ b/R/run_magic.R
@@ -80,7 +80,7 @@ run_magic <- function(data, t_diffusion, lib_size_norm=TRUE,
   W <- as.matrix(W) # to dense matrix
 
   print('Diffusing')
-  W_t <- W^t
+  W_t <- W^t_diffusion
 
   print('Imputing')
   data_imputed <- W_t %*% as.matrix(data)


### PR DESCRIPTION
There's a small typo in the R implementation. I believe W^t was meant to be W^t_diffusion (to raise it to the power of the diffusion parameter). Apologies if this was not the intended use but currently W^t outputs an error because the variable was not declared.